### PR TITLE
Update demo to use latest BIG-IP modules from Terraform registry

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,7 @@
 # These github actions will update Terraform section(s) of README(s), and
 # perform linting using pre-commit.
 ---
+# spell-checker: ignore yamllint chmod
 # yamllint disable rule:line-length
 name: pre-commit
 
@@ -17,13 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install terraform-docs
         run: |
-          sudo curl -sLo /usr/local/bin/terraform-docs https://github.com/segmentio/terraform-docs/releases/download/v0.9.1/terraform-docs-v0.9.1-linux-amd64
+          sudo curl -sLo /usr/local/bin/terraform-docs https://github.com/segmentio/terraform-docs/releases/download/v0.10.1/terraform-docs-v0.10.1-linux-amd64
           sudo chmod 0755 /usr/local/bin/terraform-docs
       - uses: actions/setup-python@v2
-      - name: set PY
-        run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 ---
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.39.0
+    rev: v1.45.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.3.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
@@ -15,6 +15,6 @@ repos:
       - id: sort-simple-yaml
       - id: trailing-whitespace
   - repo: https://github.com/thoughtworks/talisman
-    rev: v1.9.0
+    rev: scanwithrc
     hooks:
       - id: talisman-commit

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,8 +1,9 @@
+# spell-checker: ignore fileignoreconfig bigip
 fileignoreconfig:
 - filename: .github/workflows/pre-commit.yml
   checksum: 71fea73f97b2882cc899f729b9e9c2b79cd5a199aecdb9a28794e64d4fda859e
 - filename: bigip.tf
-  checksum: 46fdf3f730e4351a954dd16d0b2df040723f13c684eb83904217714e9d2306b9
+  checksum: 6a3be827b52b7a7bdd3897a79a531ed83649edf74a20f84412098025241c498e
 - filename: main.tf
   checksum: b9898dc3dc2c907dd9aa4dfb593f61c4d45edcbc91540f143642dc1951ac4f0b
 - filename: README.md

--- a/README.md
+++ b/README.md
@@ -194,15 +194,15 @@ endpoints, and install run-time libraries from a GCS bucket.
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12 |
-| google | ~>3.39 |
-| google | ~>3.39 |
+| google | ~>3.44 |
+| google | ~>3.44 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | ~>3.39 ~>3.39 |
-| google.executor | ~>3.39 ~>3.39 |
+| google | ~>3.44 ~>3.44 |
+| google.executor | ~>3.44 ~>3.44 |
 | random | n/a |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ endpoints, and install run-time libraries from a GCS bucket.
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12 |
+| terraform | ~> 0.12, < 0.13 |
 | google | ~>3.44 |
 | google | ~>3.44 |
 

--- a/bastion.tf
+++ b/bastion.tf
@@ -1,7 +1,7 @@
 # Create an IAP-backed bastion, installing tinyproxy from GCS bucket
 module "bastion" {
   source                     = "terraform-google-modules/bastion-host/google"
-  version                    = "2.7.0"
+  version                    = "2.10.0"
   project                    = var.project_id
   service_account_name       = format("%s-bastion", var.prefix)
   name                       = format("%s-bastion", var.prefix)

--- a/bigip.tf
+++ b/bigip.tf
@@ -7,7 +7,8 @@
 
 # Create a custom CFE role at the project
 module "cfe_role" {
-  source      = "git::https://github.com/memes/f5-google-terraform-modules//modules/big-ip/cfe/role?ref=1.1.0"
+  source      = "memes/f5-bigip/google//modules/cfe-role"
+  version     = "1.3.1"
   target_type = "project"
   target_id   = var.project_id
   title       = format("CFE role for %s demo", var.prefix)
@@ -58,7 +59,8 @@ locals {
 # Enable ConfigSync firewall rules between BIG-IP instances using the opinionated
 # Firewall module for CFE
 module "cfe_fw" {
-  source                   = "git::https://github.com/memes/f5-google-terraform-modules//modules/big-ip/cfe/firewall?ref=1.1.0"
+  source                   = "memes/f5-bigip/google//modules/configsync-fw"
+  version                  = "1.3.1"
   project_id               = var.project_id
   bigip_service_account    = local.bigip_sa
   management_firewall_name = format("allow-configsync-mgt-%s", var.prefix)
@@ -134,7 +136,8 @@ module "int_ips" {
 
 # Stand-up a 2 instance HA pair with CFE support
 module "cfe" {
-  source                            = "git::https://github.com/memes/f5-google-terraform-modules//modules/big-ip/cfe?ref=1.1.0"
+  source                            = "memes/f5-bigip/google//modules/cfe"
+  version                           = "1.3.1"
   project_id                        = var.project_id
   instance_name_template            = format("%s-bigip-%%d", var.prefix)
   zones                             = var.bigip_zones

--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "random_id" "bucket" {
 # can be created with same prefix without waiting.
 module "cfe_bucket" {
   source     = "terraform-google-modules/cloud-storage/google"
-  version    = "1.6.0"
+  version    = "1.7.2"
   project_id = var.project_id
   prefix     = var.prefix
   names      = [random_id.bucket.hex]

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@
 # credenitals" indicates that the calling user must (re-)authenticate application
 # default credentials using `gcloud auth application-default login`.
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 0.12, < 0.13"
   # The location and path for GCS state storage must be specified in an environment
   # file(s) via `-backend-config env/ENV/base.config`
   backend "gcs" {}

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,7 +6,7 @@ EOD
 }
 
 output "admin_password_key" {
-  value       = google_secret_manager_secret.admin_password.id
+  value       = module.admin_password.id
   description = <<EOD
 The name of the Secret Manager key that contains the generated admin password.
 EOD

--- a/providers.tf
+++ b/providers.tf
@@ -7,7 +7,7 @@
 # Instantiate a google provider aliased as 'executor'. This provider will use
 # the calling user's credentials to authenticate to GCP APIs.
 provider "google" {
-  version = "~>3.39"
+  version = "~>3.44"
   alias   = "executor"
 }
 
@@ -35,6 +35,6 @@ data "google_service_account_access_token" "sa_token" {
 # with the target service account, or the caller. These are the providers that
 # will be used for resource creation.
 provider "google" {
-  version      = "~>3.39"
+  version      = "~>3.44"
   access_token = length(data.google_service_account_access_token.sa_token) == 1 ? element(data.google_service_account_access_token.sa_token, 0).access_token : null
 }


### PR DESCRIPTION
Functionally unchanged; this is a maintenance only action.

- switch BIG-IP modules from GitHub references to published Terraform 0.12 modules
- set semver restriction to Terraform 0.12 in main
- update GitHub action and pre-commit plugins to latest